### PR TITLE
keypress

### DIFF
--- a/purescript/terminal/spago.dhall
+++ b/purescript/terminal/spago.dhall
@@ -3,7 +3,15 @@ Welcome to a Spago project!
 You can edit this file as you like.
 -}
 { name = "my-project"
-, dependencies = [ "console", "effect", "psci-support" ]
+, dependencies =
+  [ "console"
+  , "effect"
+  , "generics-rep"
+  , "node-process"
+  , "node-streams"
+  , "promises"
+  , "psci-support"
+  ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/purescript/terminal/src/Main.js
+++ b/purescript/terminal/src/Main.js
@@ -1,3 +1,34 @@
 exports.consoleClear
   = console.clear;
 
+exports.onKeypressImpl = function (input, output, terminal, f) {
+  // const readline = require("readline");
+  // const rl = readline.createInterface({
+  //   input: input,
+  //   output: output,
+  //   prompt:"",
+  //   terminal: terminal
+  // });
+  // const a = await process.stdin.on('keypress', (c, k) => {
+  //   return "hoge"
+  // });
+  // return a
+  const readline = require("readline");
+  const rl = readline.createInterface({
+     input: input,
+     output: output,
+      prompt:"",
+     terminal: terminal
+  });
+  return function() {
+  process.stdin.on('keypress', (c, k) => {
+    // console.log(c)
+    //console.log(k)
+    // return k
+    f(k)()
+  });
+  }
+}
+
+
+

--- a/purescript/terminal/src/Main.js
+++ b/purescript/terminal/src/Main.js
@@ -2,31 +2,17 @@ exports.consoleClear
   = console.clear;
 
 exports.onKeypressImpl = function (input, output, terminal, f) {
-  // const readline = require("readline");
-  // const rl = readline.createInterface({
-  //   input: input,
-  //   output: output,
-  //   prompt:"",
-  //   terminal: terminal
-  // });
-  // const a = await process.stdin.on('keypress', (c, k) => {
-  //   return "hoge"
-  // });
-  // return a
   const readline = require("readline");
   const rl = readline.createInterface({
-     input: input,
-     output: output,
-      prompt:"",
-     terminal: terminal
+    input: input,
+    output: output,
+    prompt: "",
+    terminal: terminal
   });
   return function() {
-  process.stdin.on('keypress', (c, k) => {
-    // console.log(c)
-    //console.log(k)
-    // return k
-    f(k)()
-  });
+    process.stdin.on('keypress', (c, k) => {
+      f(k)()
+    });
   }
 }
 

--- a/purescript/terminal/src/Main.purs
+++ b/purescript/terminal/src/Main.purs
@@ -3,14 +3,16 @@ module Main where
 import Prelude
 
 import Effect (Effect)
-import Effect.Console (log)
-import Node.Stream (Readable, Writable)
+import Effect.Console (log, clear)
+import Node.Stream (Readable, Writable, write)
 import Effect.Promise (Promise)
 import Node.Process (stdin, stdout)
 import Data.Function.Uncurried (Fn4, runFn4)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.Maybe (Maybe(..))
+import Node.Encoding(Encoding(..))
+import Node.Buffer(fromString, create)
 
 foreign import consoleClear :: Effect Unit
 
@@ -26,9 +28,12 @@ main = do
   -- consoleClear
   log "🍝"
   log "🍝"
-  onKeypress stdin stdout true $ \x -> log $ show x
+  onKeypress stdin stdout true $ \x -> do
+                                   clear
+                                   log $ show x
 
 
+-- process.stdout.write('\033c') // clear console
 
 
 type PressedKey = String

--- a/purescript/terminal/src/Main.purs
+++ b/purescript/terminal/src/Main.purs
@@ -4,13 +4,58 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
+import Node.Stream (Readable, Writable)
+import Effect.Promise (Promise)
+import Node.Process (stdin, stdout)
+import Data.Function.Uncurried (Fn4, runFn4)
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
+import Data.Maybe (Maybe(..))
 
 foreign import consoleClear :: Effect Unit
+
+-- ref: https://github.com/purescript-node/purescript-node-streams/blob/v4.0.1/src/Node/Stream.purs
+foreign import onKeypressImpl :: Fn4 (Readable ()) (Writable ()) (Boolean) (PressedKeyInfo -> Effect Unit) (Effect Unit)
+onKeypress :: Readable () -> Writable () -> Boolean -> (PressedKeyInfo -> Effect Unit) -> Effect Unit
+onKeypress = runFn4 onKeypressImpl
 
 main :: Effect Unit
 main = do
   log "🍝"
   log "🍝"
-  consoleClear
+  -- consoleClear
   log "🍝"
   log "🍝"
+  onKeypress stdin stdout true $ \x -> log $ show x
+
+
+
+
+type PressedKey = String
+
+newtype PressedKeyInfo = PressedKeyInfo {
+  sequence :: String
+ ,name :: String
+ ,ctrl :: Boolean
+ ,meta :: Boolean
+ ,shift :: Boolean
+}
+-- data PressedKeyInfo = PressedKeyInfo String String Boolean Boolean Boolean
+
+derive instance genericPressedKeyInfo :: Generic PressedKeyInfo _
+instance showPressedKeyInfo :: Show PressedKeyInfo where
+  show (PressedKeyInfo {
+  sequence : s
+ ,name : n
+ ,ctrl : c
+ ,meta : m
+ ,shift : sh
+}) = "{ sequence: " <> s <> " ,name: " <> n <> " ,ctrl: " <> (show c) <> " ,meta: " <> (show m) <> " ,shift: " <> (show sh) <> " }"
+
+
+-- foreign import onDataEitherImpl :: forall r . (Chunk -> Either String Buffer) -> Readable r -> (Either String Buffer -> Effect Unit) -> Effect Unit
+
+
+
+
+

--- a/purescript/terminal/src/Main.purs
+++ b/purescript/terminal/src/Main.purs
@@ -4,15 +4,10 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log, clear)
-import Node.Stream (Readable, Writable, write)
-import Effect.Promise (Promise)
+import Node.Stream (Readable, Writable)
 import Node.Process (stdin, stdout)
 import Data.Function.Uncurried (Fn4, runFn4)
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
-import Data.Maybe (Maybe(..))
-import Node.Encoding(Encoding(..))
-import Node.Buffer(fromString, create)
 
 foreign import consoleClear :: Effect Unit
 
@@ -23,20 +18,8 @@ onKeypress = runFn4 onKeypressImpl
 
 main :: Effect Unit
 main = do
-  log "🍝"
-  log "🍝"
-  -- consoleClear
-  log "🍝"
-  log "🍝"
-  onKeypress stdin stdout true $ \x -> do
-                                   clear
-                                   log $ show x
+  onKeypress stdin stdout true getKeyName
 
-
--- process.stdout.write('\033c') // clear console
-
-
-type PressedKey = String
 
 newtype PressedKeyInfo = PressedKeyInfo {
   sequence :: String
@@ -45,7 +28,6 @@ newtype PressedKeyInfo = PressedKeyInfo {
  ,meta :: Boolean
  ,shift :: Boolean
 }
--- data PressedKeyInfo = PressedKeyInfo String String Boolean Boolean Boolean
 
 derive instance genericPressedKeyInfo :: Generic PressedKeyInfo _
 instance showPressedKeyInfo :: Show PressedKeyInfo where
@@ -55,12 +37,17 @@ instance showPressedKeyInfo :: Show PressedKeyInfo where
  ,ctrl : c
  ,meta : m
  ,shift : sh
-}) = "{ sequence: " <> s <> " ,name: " <> n <> " ,ctrl: " <> (show c) <> " ,meta: " <> (show m) <> " ,shift: " <> (show sh) <> " }"
+}) = "{ sequence: " <> (show s) <> " ,name: " <> n <> " ,ctrl: " <> (show c) <> " ,meta: " <> (show m) <> " ,shift: " <> (show sh) <> " }"
 
 
--- foreign import onDataEitherImpl :: forall r . (Chunk -> Either String Buffer) -> Readable r -> (Either String Buffer -> Effect Unit) -> Effect Unit
-
-
-
-
+getKeyName :: PressedKeyInfo -> Effect Unit
+getKeyName (PressedKeyInfo pki) = do
+  clear
+  let name = case pki.name of
+       "h" -> "left"
+       "j" -> "down"
+       "k" -> "up"
+       "l" -> "right"
+       _   -> pki.name
+  log name
 


### PR DESCRIPTION
`V{ sequence: V ,name: v ,ctrl: false ,meta: false ,shift: true }`
先頭の `V` 標準入力が出ちゃってるので出さないようにする